### PR TITLE
Install Grafana without proxy in the case that OAuth is disabled but Grafana is enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ stages:
   - test
 
 env:
-  - ANSIBLE_ROLES_PATH=$ANSIBLE_ROLES_PATH:$PWD/roles OPENSHIFT_VERSION=latest
   - ANSIBLE_ROLES_PATH=$ANSIBLE_ROLES_PATH:$PWD/roles OPENSHIFT_VERSION=v3.9.0
+  - ANSIBLE_ROLES_PATH=$ANSIBLE_ROLES_PATH:$PWD/roles OPENSHIFT_VERSION=v3.10
 
 before_install:
   - sudo apt-get update -qq
@@ -57,7 +57,7 @@ script:
   - export APB_NAME=prometheus-apb
   - apb build
   - sudo docker cp $(docker create docker.io/openshift/origin:$OPENSHIFT_VERSION):/bin/oc /usr/local/bin/oc
-  - oc cluster up --version=$OPENSHIFT_VERSION
+  - oc cluster up
   - oc login -u system:admin
   - oc new-project $APB_NAME
   - docker run --rm --net=host -v $HOME/.kube:/opt/apb/.kube:z -u $UID $APB_NAME test --extra-vars "travis=true" 

--- a/roles/prometheus-apb/tasks/main.yml
+++ b/roles/prometheus-apb/tasks/main.yml
@@ -12,6 +12,10 @@
     include_tasks: prometheus.yml
     when: not PROMETHEUS_SECURED_DEPLOYMENT | bool
 
+  - name: "[PROMETHEUS APB][MAIN] Deploying Grafana"
+    include_tasks: prometheus-grafana.yml
+    when: not PROMETHEUS_SECURED_DEPLOYMENT and DEPLOY_GRAFANA | bool
+
   - name: "[PROMETHEUS APB][MAIN] Deploying Prometheus-Oauth"
     include_tasks: prometheus-oauth.yml
     when: PROMETHEUS_SECURED_DEPLOYMENT | bool
@@ -21,7 +25,7 @@
 
   - name: "[PROMETHEUS APB][MAIN] Deploying Prometheus-Grafana"
     include_tasks: prometheus-grafana-oauth.yml
-    when: DEPLOY_GRAFANA | bool
+    when: PROMETHEUS_SECURED_DEPLOYMENT and DEPLOY_GRAFANA | bool
   when: mode == 'provision'
 
 - block:

--- a/roles/prometheus-apb/tasks/prometheus-grafana.yml
+++ b/roles/prometheus-apb/tasks/prometheus-grafana.yml
@@ -1,0 +1,262 @@
+---
+- name: "[PROMETHEUS-GRAFANA][{{ mode | upper }}] Set to {{ state }} Grafana ServiceAccount"
+  k8s_v1_service_account:
+    state: "{{ state }}"
+    name: "{{ service_name_graf }}"
+    namespace: "{{ namespace }}"
+  register: prometheus_grafana_sa
+
+- name: "[PROMETHEUS-GRAFANA][{{ mode | upper }}] Recover secret name"
+  set_fact:
+    prometheus_grafana_sa_token_name: "{{ item.name }}"
+  with_list: "{{ prometheus_grafana_sa.service_account.secrets }}"
+  when: "'prometheus-grafana-token' in item.name"
+
+- name: "[PROMETHEUS-GRAFANA][{{ mode | upper }}] Recovering Service Account token"
+  k8s_v1_secret:
+    state: "{{ state }}"
+    name: "{{ prometheus_grafana_sa_token_name }}"
+    namespace: "{{ namespace }}"
+  register: prometheus_grafana_sa_token
+
+- name: "[PROMETHEUS-GRAFANA][{{ mode | upper }}] Creating a fact with the secret token of Service Account"
+  set_fact:
+    prometheus_grafana_sa_token: "{{ prometheus_grafana_sa_token.secret.data.token | b64decode }}"
+
+- name: "[PROMETHEUS-GRAFANA][{{ mode | upper }}] Set to {{ state }} RoleBinding for Service Account"
+  k8s_v1beta1_role_binding:
+    state: "{{ state }}"
+    name: "{{ service_name_graf }}-view"
+    namespace: "{{ namespace }}"
+    role_ref_name: view
+    role_ref_kind: ClusterRole
+    subjects:
+    - kind: ServiceAccount
+      name: "{{ service_name_graf }}"
+      namespace: "{{ namespace }}"
+
+- name: "[PROMETHEUS-GRAFANA][{{ mode | upper }}] Set to {{ state }} ImageStream for Grafana image"
+  openshift_v1_image_stream:
+    state: "{{ state }}"
+    name: "{{ item.name }}"
+    namespace: "{{ namespace }}"
+    labels:
+      app: "{{ service_name }}"
+      service: "{{ item.name }}"
+    lookup_policy_local: False 
+    tags:
+      - name: "{{ item.tag_name }}"
+    docker_image_repository: "{{ item.image }}"
+  with_items:
+    - { name: "{{ service_name_graf }}", image: "{{ prometheus_grafana_image }}", tag_name: "{{ prometheus_grafana_version }}"  }
+  register: prometheus_grafana_is
+
+- name: "[PROMETHEUS-GRAFANA][{{ mode | upper }}] Set to {{ state }} Grafana ConfigMap resource"
+  k8s_v1_config_map:
+    state: "{{ state }}"
+    name: "{{ prometheus_grafana_configmap_name }}"
+    namespace: "{{ namespace }}"
+    labels:
+      app: "{{ service_name }}"
+      service: "{{ service_name_graf }}"
+    resource_definition:
+      kind: 'ConfigMap'
+      apiVersion: 'v1'
+      metadata:
+        name: "{{ prometheus_grafana_configmap_name }}"
+        namespace: "{{ namespace }}"
+      data:
+        defaults.ini: "{{ lookup('template', 'prometheus-grafana-config-map.ini.j2') }}"
+  register: prometheus_grafana_cm
+
+- name: "[PROMETHEUS-GRAFANA][{{ mode | upper }}] Set to {{ state }} Grafana PVC for Persistent plan"
+  k8s_v1_persistent_volume_claim:
+    state: "{{ state }}"
+    name: "{{ prometheus_grafana_data_pvc_name }}"
+    namespace: "{{ namespace }}"
+    labels:
+      app: "{{ service_name }}"
+      service: "{{ service_name_graf }}"
+    access_modes:
+      - ReadWriteOnce
+    resources_requests:
+      storage: "{{ PROMETHEUS_GRAFANA_STORAGE_SIZE }}Gi"
+  register: grafana_pvc
+  when: _apb_plan_id == 'persistent'
+
+- name: "[PROMETHEUS-GRAFANA][{{ mode | upper }}] Set to {{ state }} the Grafana Deployment Config for Persistent plan"
+  openshift_v1_deployment_config:
+    state: "{{ state }}"
+    name: "{{ service_name_graf }}"
+    namespace: "{{ namespace }}"
+    labels:
+      app: "{{ service_name }}"
+      service: "{{ service_name_graf }}"
+    replicas: 1
+    selector:
+      app: "{{ service_name }}"
+      service: "{{ service_name_graf }}"
+    spec_template_metadata_labels:
+      app: "{{ service_name }}"
+      service: "{{ service_name_graf }}"
+    spec_template_spec_service_account_name: "{{ service_name_graf }}"
+    containers:
+      ## Grafana
+      - name: "{{ service_name_graf }}"
+        image: "{{ prometheus_grafana_image }}:{{ prometheus_grafana_version }}"
+        imagePullPolicy: Always
+        ports:
+        - container_port: "{{ prometheus_grafana_port }}"
+          protocol: TCP
+        volume_mounts:
+          - mount_path: "{{ prometheus_grafana_base_path }}/conf"
+            name: "{{ prometheus_grafana_configmap_name }}"
+          - mount_path: "{{ prometheus_grafana_base_path }}/data"
+            name: "{{ prometheus_grafana_data_volume_name }}"
+          - mount_path: "{{ prometheus_grafana_base_path }}/dashboards"
+            name: "{{ prometheus_grafana_dashboards_configmap_name }}"
+        command: ['./bin/grafana-server']
+        liveness_probe:
+          initial_delay_seconds: 30
+          httpGet:
+            port: 3000
+          timeout_seconds: 3
+          period_seconds: 10
+        readiness_probe:
+          initial_delay_seconds: 30
+          httpGet:
+            port: 3000
+          timeout_seconds: 3
+          period_seconds: 10
+    volumes:
+      - name: "{{ prometheus_grafana_configmap_name }}"
+        config_map:
+          name: "{{ prometheus_grafana_configmap_name }}"
+      - name: "{{ prometheus_grafana_data_volume_name }}"
+        persistent_volume_claim:
+          claim_name: "{{ prometheus_grafana_data_pvc_name }}"
+      - name: "{{ prometheus_grafana_dashboards_configmap_name }}"
+        config_map:
+          name: "{{ prometheus_grafana_dashboards_configmap_name }}"
+    restart_policy: Always
+    termination_grace_period_seconds: 30
+    test: false
+    triggers:
+      - type: ConfigChange
+  register: prometheus_grafana_dc
+  when: _apb_plan_id == 'persistent'
+
+- name: "[PROMETHEUS-GRAFANA][{{ mode | upper }}] Set to {{ state }} the Prometheus Deployment Config for Ephemeral plan"
+  openshift_v1_deployment_config:
+    state: "{{ state }}"
+    name: "{{ service_name_graf }}"
+    namespace: "{{ namespace }}"
+    labels:
+      app: "{{ service_name }}"
+      service: "{{ service_name_graf }}"
+    replicas: 1
+    selector:
+      app: "{{ service_name }}"
+      service: "{{ service_name_graf }}"
+    spec_template_metadata_labels:
+      app: "{{ service_name }}"
+      service: "{{ service_name_graf }}"
+    spec_template_spec_service_account_name: "{{ service_name_graf }}"
+    containers:
+      ## Prometheus DC
+      - name: "{{ service_name_graf }}"
+        image: "{{ prometheus_grafana_image }}:{{ prometheus_grafana_version }}"
+        imagePullPolicy: Always
+        ports:
+        - container_port: "{{ prometheus_grafana_port }}"
+          protocol: TCP
+        volume_mounts:
+          - mount_path: "{{ prometheus_grafana_base_path }}/conf"
+            name: "{{ prometheus_grafana_configmap_name }}"
+          - mount_path: "{{ prometheus_grafana_base_path }}/data"
+            name: "{{ prometheus_grafana_data_volume_name }}"
+          - mount_path: "{{ prometheus_grafana_base_path }}/dashboards"
+            name: "{{ prometheus_grafana_dashboards_configmap_name }}"
+        command: ['./bin/grafana-server']
+        liveness_probe:
+          initial_delay_seconds: 30
+          httpGet:
+            port: 3000
+          timeout_seconds: 3
+          period_seconds: 10
+        readiness_probe:
+          initial_delay_seconds: 30
+          httpGet:
+            port: 3000
+          timeout_seconds: 3
+          period_seconds: 10
+    volumes:
+      - name: "{{ prometheus_grafana_configmap_name }}"
+        config_map:
+          defaultMode: 420
+          name: "{{ prometheus_grafana_configmap_name }}"
+      - name: "{{ prometheus_grafana_data_volume_name }}"
+        emptyDir: {}
+      - name: "{{ prometheus_grafana_dashboards_configmap_name }}"
+        config_map:
+          name: "{{ prometheus_grafana_dashboards_configmap_name }}"
+    restart_policy: Always
+    termination_grace_period_seconds: 30
+    test: false
+    triggers:
+      - type: ConfigChange
+  register: prometheus_grafana_dc
+  when: _apb_plan_id == 'ephemeral'
+
+- name: "[PROMETHEUS-GRAFANA][{{ mode | upper }}] Set to {{ state }} Grafana Service"
+  k8s_v1_service:
+    state: "{{ state }}"
+    name: "{{ service_name_graf }}"
+    namespace: "{{ namespace }}"
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/scheme: https
+      service.alpha.openshift.io/serving-cert-secret-name: "{{ prometheus_grafana_proxy_tls_secret_name }}"
+    labels:
+      app: "{{ service_name }}"
+      service: "{{ service_name_graf }}"
+    selector:
+      app: "{{ service_name }}"
+      service: "{{ service_name_graf }}"
+    ports:
+    - name: "{{ service_name_graf }}-{{ prometheus_grafana_port }}"
+      port: "{{ prometheus_grafana_port }}"
+      target_port: "{{ prometheus_grafana_port }}"
+  register: prometheus_grafana_svc
+
+- name: "[PROMETHEUS-GRAFANA][{{ mode | upper }}] Set to {{ state }} Grafana Route"
+  openshift_v1_route:
+    state: "{{ state }}"
+    name: "{{ service_name_graf }}"
+    namespace: '{{ namespace }}'
+    labels:
+      app: "{{ service_name }}"
+      service: "{{ service_name_graf }}"
+    to_name: "{{ service_name_graf }}"
+    port_target_port: "{{ service_name_graf }}-{{ prometheus_grafana_port }}"
+  register: prometheus_grafana_route
+
+# Feature only for Grafana 5+ version
+- name: "[PROMETHEUS-GRAFANA][{{ mode | upper }}] Set to {{ state }} Grafana ConfigMap Dashboards resource"
+  k8s_v1_config_map:
+    state: "{{ state }}"
+    name: "{{ prometheus_grafana_dashboards_configmap_name }}"
+    namespace: "{{ namespace }}"
+    labels:
+      app: "{{ service_name }}"
+      service: "{{ service_name_graf_proxy }}"
+    resource_definition:
+      kind: 'ConfigMap'
+      apiVersion: 'v1'
+      metadata:
+        name: "{{ prometheus_grafana_dashboards_configmap_name }}"
+        namespace: "{{ namespace }}"
+      data:
+        default.yml: "{{ lookup('template', 'prometheus-grafana-dashboards-config-map.yml.j2') }}"
+  register: prometheus_grafana_dash_cm
+

--- a/roles/prometheus-apb/tasks/test.yml
+++ b/roles/prometheus-apb/tasks/test.yml
@@ -36,7 +36,7 @@
   delay: 20
   failed_when: grafana.status == 404
   until: '"Sign in with an OpenShift account" in webpage.content'
-  when: DEPLOY_GRAFANA | bool
+  when: PROMETHEUS_SECURED_DEPLOYMENT and DEPLOY_GRAFANA | bool
 
 - name: "[PROMETHEUS APB][{{ mode | upper }}] Saving Tests results on error"
   asb_save_test_result:
@@ -44,4 +44,4 @@
     msg: "Test Failed. Error connecting with Prometheus Server. Data - {{ webpage }}"
   when:
     - webpage.failed | bool
-    - DEPLOY_GRAFANA | bool
+    - PROMETHEUS_SECURED_DEPLOYMENT and DEPLOY_GRAFANA | bool


### PR DESCRIPTION
If you choose to deselect the Oauth checkbox, but leave the Grafana checkbox checked, Grafana is not installed.    Grafana should be installed in this case, without a proxy.    

I had trouble getting the datasource creation working though - I'll add that in a later PR if I can get it working. 